### PR TITLE
Establish compatibility with GHC 8.4.1.

### DIFF
--- a/src/Network/JSONApi/Document.hs
+++ b/src/Network/JSONApi/Document.hs
@@ -120,7 +120,7 @@ constrain the 'Value' to a heterogeneous list of Resource types.
 See 'mkIncludedResource' for creating 'Included' types.
 -}
 newtype Included = Included (DL.DList Value)
-  deriving (Show, Monoid)
+  deriving (Show, Semigroup, Monoid)
 
 getIncluded :: Included -> [Value]
 getIncluded (Included d) = DL.toList d

--- a/src/Network/JSONApi/Link.hs
+++ b/src/Network/JSONApi/Link.hs
@@ -33,7 +33,7 @@ Example JSON:
 Specification: <http://jsonapi.org/format/#document-links>
 -}
 newtype Links = Links { fromLinks :: HM.HashMap Rel Href }
-  deriving (Show, Eq, ToJSON, FromJSON, G.Generic, Monoid, Hashable)
+  deriving (Show, Eq, ToJSON, FromJSON, G.Generic, Semigroup, Monoid, Hashable)
 
 type Rel = Text
 type Href = Text

--- a/src/Network/JSONApi/Meta.hs
+++ b/src/Network/JSONApi/Meta.hs
@@ -38,7 +38,7 @@ Example JSON:
 Specification: <http://jsonapi.org/format/#document-meta>
 -}
 newtype Meta = Meta { fromMeta :: Object }
-  deriving (Show, Eq, G.Generic, Monoid, ToJSON, FromJSON, Hashable)
+  deriving (Show, Eq, G.Generic, Semigroup, Monoid, ToJSON, FromJSON, Hashable)
 
 {- |
 Convienience class for constructing a Meta type

--- a/src/Network/JSONApi/Resource.hs
+++ b/src/Network/JSONApi/Resource.hs
@@ -78,7 +78,7 @@ instance AE.FromJSON Relationship where
     return $ Relationship d (fromMaybe mempty l)
 
 newtype Relationships = Relationships { fromRelationships :: HM.HashMap Text Relationship }
-  deriving (Show, Eq, Generic, Monoid, ToJSON, FromJSON)
+  deriving (Show, Eq, Generic, Semigroup, Monoid, ToJSON, FromJSON)
 
 deriving instance Hashable Relationships
 


### PR DESCRIPTION
Hi,

I had an issue with LTS-12.9, which ships with GHC 8.4.3. Since GHC 8.4.1 Semigroup is a superclass of Monoid, so I had to add Semigroup to the deriving clause.

Sincerely yours,
Andre